### PR TITLE
Garante execução no CodeIgniter 4

### DIFF
--- a/app/Libraries/cCrud.php
+++ b/app/Libraries/cCrud.php
@@ -493,11 +493,16 @@ class cCrud
     public $ci = null;
 
     /**
-     * constructor, sets basic xcrud vars (they can be changed by public
-     * pethods)
+     * Construtor que define as variáveis básicas do cCrud,
+     * podendo ser alteradas por métodos públicos.
      */
     protected function __construct()
     {
+        // Verifica se o pacote está sendo utilizado dentro do CodeIgniter 4
+        if (!defined('CI_VERSION') || version_compare(CI_VERSION, '4.0.0', '<')) {
+            throw new \Error('Este pacote requer a execução dentro do CodeIgniter 4.');
+        }
+
         $this->config = class_exists('\\Config\\cCrudConfig') ? new \Config\cCrudConfig() : new cCrudConfig();
 
         $this->config->scripts_url = self::check_url($this->config->scripts_url, true);


### PR DESCRIPTION
## Resumo
- Assegura que o pacote seja utilizado apenas dentro do CodeIgniter 4
- Atualiza comentários do construtor para português

## Testes
- `php -l app/Libraries/cCrud.php`
- `composer validate --no-check-all --ansi`


------
https://chatgpt.com/codex/tasks/task_e_68aa2eaebd68832ab83a371a04e2a15d