### PR TITLE
feat: allow overriding config from app

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -43,7 +43,7 @@ class Database
             $instance_name = 'db_instance_default';
         }
         if (! isset(self::$_instance[$instance_name]) or null === self::$_instance[$instance_name]) {
-            $config = config('cCrud\cCrud');
+            $config = cCrudConfig::instance();
             if (! is_array($params)) {
                 $dbuser     = $config->dbuser;
                 $dbpass     = $config->dbpass;

--- a/src/cCrud.php
+++ b/src/cCrud.php
@@ -517,7 +517,7 @@ class cCrud
             throw new RuntimeException(lang('cCrud.ci4_required'));
         }
 
-        $this->config = class_exists('\Config\cCrud') ? new \Config\cCrud() : new cCrudConfig();
+        $this->config = cCrudConfig::instance();
 
         $this->config->scripts_url = self::check_url($this->config->scripts_url, true);
         $this->config->editor_url = self::check_url($this->config->editor_url);
@@ -655,7 +655,7 @@ class cCrud
     protected static function init_prepare($method = false)
     {
         $session = config('Session');
-        $config  = config('cCrud\cCrud');
+        $config  = cCrudConfig::instance();
         switch ($method) {
             case 'post':
                 $sess_name = ($config->dynamic_session && isset($_POST['xcrud']['sess_name']) && $_POST['xcrud']['sess_name']) ? $_POST['xcrud']['sess_name'] : $session->cookieName;
@@ -9664,7 +9664,6 @@ class cCrud
      */
     protected static function _get_language_static()
     {
-        $config = config('cCrud\cCrud');
         self::$lang_arr = lang('cCrud', [], \Config\App::$defaultLocale);
         if (! self::$lang_arr) {
             self::$lang_arr = lang('cCrud', [], 'en');
@@ -9823,7 +9822,7 @@ class cCrud
     public static function load_css()
     {
         $out    = '';
-        $config = config('cCrud\cCrud');
+        $config = cCrudConfig::instance();
 
         if (! self::$js_loaded && ! self::$instance) {
             $config->scripts_url     = self::check_url($config->scripts_url, true);
@@ -9863,7 +9862,7 @@ class cCrud
             $language = \Config\App::$defaultLocale;
             self::_get_language_static();
         }
-        $config = config('cCrud\cCrud');
+        $config = cCrudConfig::instance();
 
         if (! self::$css_loaded && ! self::$instance) {
             $config->scripts_url     = self::check_url($config->scripts_url, true);

--- a/src/config/cCrud.php
+++ b/src/config/cCrud.php
@@ -159,6 +159,48 @@ class cCrud extends BaseConfig
     public $xss_disalowed_attibutes = array('on\w*', /*'style',*/ 'xmlns', 'formaction'); // Remove bad attributes such as style, onclick and xmlns
     public $xss_naughty_html = 'alert|applet|audio|basefont|base|behavior|bgsound|blink|body|embed|expression|form|frameset|frame|head|html|ilayer|input|isindex|layer|link|meta|object|plaintext|script|textarea|title|video|xml|xss'; // If a tag containing any of the words in the list below is found, the tag gets converted to entities.
     public $xss_naughty_scripts = 'alert|cmd|passthru|eval|exec|expression|system|fopen|fsockopen|file|file_get_contents|readfile|unlink'; // imilar to above, only instead of looking for tags it looks for PHP and JavaScript commands that are disallowed.  Rather than removing the code, it simply converts the parenthesis to entities rendering the code un-executable.
-    
+
+
+    /**
+     * Instância da configuração carregada.
+     *
+     * @var self|null
+     */
+    private static ?self $instance = null;
+
+    /**
+     * Retorna a instância das configurações, aplicando sobrecargas
+     * definidas pelo consumidor do pacote.
+     *
+     * @return self Configurações do cCrud
+     */
+    public static function instance(): self
+    {
+        if (self::$instance !== null) {
+            return self::$instance;
+        }
+
+        // Inicia com a configuração base
+        $config = new self();
+
+        // Carrega configurações personalizadas da aplicação, se existirem
+        if (defined('APPPATH')) {
+            $path = rtrim(APPPATH, '\\/') . '/cCrud.php';
+            if (is_file($path)) {
+                $appConfig = require $path;
+                if (is_array($appConfig)) {
+                    foreach ($appConfig as $key => $value) {
+                        if (property_exists($config, $key)) {
+                            $config->$key = $value;
+                        }
+                    }
+                }
+            }
+        }
+
+        self::$instance = $config;
+
+        return self::$instance;
+    }
 
 }


### PR DESCRIPTION
## Summary
- add config loader that checks app/cCrud.php before falling back to package defaults
- ensure Database and cCrud use new loader

## Testing
- `php -l src/config/cCrud.php`
- `php -l src/Database.php`
- `php -l src/cCrud.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa7a8628e0832ab2a229554a77c035