### PR TITLE
Remove linha unset em construtor

### DIFF
--- a/src/cCrud.php
+++ b/src/cCrud.php
@@ -13596,18 +13596,36 @@ class cCrud
     }
 }
 
+/**
+ * Classe responsável por manipular dados enviados via POST.
+ */
 class cCrudPostdata
 {
 
+    /**
+     * Instância principal do cCrud.
+     *
+     * @var cCrud|null
+     */
     private $xcrud = null;
 
+    /**
+     * Dados recebidos via POST.
+     *
+     * @var array<string,mixed>
+     */
     private $postdata = array();
 
+    /**
+     * Inicializa a classe com os dados do formulário.
+     *
+     * @param array<string,mixed> $postdata Dados do formulário.
+     * @param cCrud               $xcrud    Instância principal do cCrud.
+     */
     public function __construct($postdata, $xcrud)
     {
         $this->xcrud = $xcrud;
         $this->postdata = $postdata;
-        unset($postdata);
     }
 
     public function set($name, $value)


### PR DESCRIPTION
## Resumo
- Remove chamada `unset($postdata)` do construtor de `cCrudPostdata`
- Documenta classe e construtor de `cCrudPostdata` em PHPDoc

## Testes
- `composer validate --strict`
- `php -l src/cCrud.php` *(falhou: Parse error: syntax error, unexpected token "protected" in src/cCrud.php on line 6132)*

------
https://chatgpt.com/codex/tasks/task_e_68ab297deb90832a90dc95cb3f0151f2