### PR TITLE
refactor: simplify postdata getter

### DIFF
--- a/src/cCrud.php
+++ b/src/cCrud.php
@@ -13629,13 +13629,18 @@ class cCrudPostdata
         return $this;
     }
 
-    public function get($name)
+    /**
+     * Retorna o valor de um campo enviado.
+     *
+     * @param string $name Nome do campo.
+     *
+     * @return mixed|null Valor do campo ou null se não existir.
+     */
+    public function get(string $name): mixed
     {
         $fdata = $this->xcrud->_parse_field_names($name, 'cCrudPostdata');
         $fname = key($fdata) /*$fdata[0]['table'] . '.' . $fdata[0]['field']*/;
-        $value = (isset($this->postdata[$fname]) ? $this->postdata[$fname] : false);
-        return /* new cCrudPostdata_item */
-        ($value);
+        return $this->postdata[$fname] ?? null;
     }
 
     public function to_array()


### PR DESCRIPTION
## Summary
- refactor Postdata getter to use null coalescing operator
- document Postdata getter return type as mixed|null

## Testing
- `composer install`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ab297f7314832aaf218d7c5086ef48