### PR TITLE
Remove unused FK helper functions

### DIFF
--- a/src/cCrud.php
+++ b/src/cCrud.php
@@ -3267,16 +3267,6 @@ class cCrud
         return $ins_id;
     }
 
-    protected function make_fk_remove($rel, $primary)
-    {
-        $db = $this->model->db;
-    }
-
-    protected function make_fk_insert($rel, $val, $primary)
-    {
-        $db = $this->model->db;
-    }
-
     /**
      *
      * @author Ariel Canal


### PR DESCRIPTION
## Summary
- remove unused `make_fk_remove` and `make_fk_insert` methods

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `php -l src/cCrud.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab29c861bc832a987f1e969ce9dd84