### PR TITLE
refactor: move Postdata class to dedicated file

### DIFF
--- a/src/Postdata.php
+++ b/src/Postdata.php
@@ -1,0 +1,99 @@
+<?php
+namespace cCrud;
+
+/**
+ * Classe responsável por manipular dados enviados via POST.
+ * Fornece métodos auxiliares para manipular, consultar e converter
+ * os valores recebidos, mantendo a consistência do cCrud.
+ */
+class Postdata
+{
+    /**
+     * Referência ao objeto principal do cCrud.
+     *
+     * @var cCrud|null
+     */
+    private ?cCrud $xcrud = null;
+
+    /**
+     * Dados recebidos via POST.
+     *
+     * @var array<string,mixed>
+     */
+    private array $postdata = [];
+
+    /**
+     * Inicializa a classe com os dados do formulário.
+     *
+     * @param array<string,mixed> $postdata Dados do formulário.
+     * @param cCrud               $xcrud    Instância principal do cCrud.
+     */
+    public function __construct(array $postdata, cCrud $xcrud)
+    {
+        $this->xcrud = $xcrud;
+        $this->postdata = $postdata;
+    }
+
+    /**
+     * Define um valor para um campo de POST.
+     *
+     * Se o nome representar múltiplos campos, todos receberão o mesmo valor.
+     *
+     * @param string $name  Nome do campo.
+     * @param mixed  $value Valor a ser atribuído.
+     *
+     * @return self
+     */
+    public function set(string $name, mixed $value): self
+    {
+        $fdata = $this->xcrud->_parse_field_names($name, 'Postdata');
+        foreach ($fdata as $key => $_) {
+            $this->postdata[$key] = $value;
+        }
+        $this->xcrud->unlock_field($name); // Garante que o campo possa ser reutilizado
+        return $this;
+    }
+
+    /**
+     * Remove um campo do conjunto de dados do POST.
+     *
+     * @param string $name Nome do campo a ser removido.
+     *
+     * @return self
+     */
+    public function del(string $name): self
+    {
+        $fdata = $this->xcrud->_parse_field_names($name, 'Postdata');
+        foreach ($fdata as $key => $_) {
+            unset($this->postdata[$key]);
+        }
+        return $this;
+    }
+
+    /**
+     * Retorna o valor de um campo enviado.
+     *
+     * @param string $name Nome do campo.
+     *
+     * @return mixed|null Valor do campo ou null se não existir.
+     */
+    public function get(string $name): mixed
+    {
+        $fdata = $this->xcrud->_parse_field_names($name, 'Postdata');
+        $fname = key($fdata);
+        return $this->postdata[$fname] ?? null;
+    }
+
+    /**
+     * Converte os dados armazenados em array.
+     *
+     * @return array<string,mixed> Dados do POST processados.
+     */
+    public function to_array(): array
+    {
+        return $this->postdata; // Entrega os dados para manipulação externa
+    }
+}
+
+// Mantém compatibilidade com o nome legado.
+class_alias(Postdata::class, __NAMESPACE__ . '\\cCrudPostdata');

--- a/src/cCrud.php
+++ b/src/cCrud.php
@@ -8,6 +8,7 @@ use CodeIgniter\I18n\Time;
 use Config\Services;
 use CodeIgniter\Encryption\EncrypterInterface;
 use CodeIgniter\Session\Session;
+use cCrud\Postdata;
 use RuntimeException;
 
 // direct access to DB driver and config
@@ -3669,7 +3670,7 @@ class cCrud
                 }
             }
 
-            $pd = new cCrudPostdata($postdata, $this);
+            $pd = new Postdata($postdata, $this);
             $postdata = $pd->to_array();
 
             if ($this->alert_create) {
@@ -13587,102 +13588,3 @@ class cCrud
     }
 }
 
-/**
- * Classe responsável por manipular dados enviados via POST.
- * Oferece métodos auxiliares para manipular, consultar e converter
- * os valores recebidos, mantendo a consistência do cCrud.
- */
-class cCrudPostdata
-{
-
-    /**
-     * Referência ao objeto principal do cCrud.
-     *
-     * @var cCrud|null
-     */
-    private $xcrud = null;
-
-    /**
-     * Dados recebidos via POST.
-     *
-     * @var array<string,mixed>
-     */
-    private $postdata = array();
-
-    /**
-     * Inicializa a classe com os dados do formulário.
-     *
-     * @param array<string,mixed> $postdata Dados do formulário.
-     * @param cCrud               $xcrud    Instância principal do cCrud.
-     */
-    public function __construct($postdata, $xcrud)
-    {
-        $this->xcrud = $xcrud;
-        $this->postdata = $postdata;
-    }
-
-    /**
-     * Define um valor para um campo de POST.
-     *
-     * Se o nome representar múltiplos campos, todos receberão o mesmo valor.
-     *
-     * @param string $name  Nome do campo.
-     * @param mixed  $value Valor a ser atribuído.
-     *
-     * @return self
-     */
-    public function set($name, $value)
-    {
-        $fdata = $this->xcrud->_parse_field_names($name, 'cCrudPostdata');
-        foreach ($fdata as $key => $_) {
-            $this->postdata[$key] = $value;
-        }
-        $this->xcrud->unlock_field($name); // Garante que o campo possa ser reutilizado
-        return $this;
-    }
-
-    /**
-     * Remove um campo do conjunto de dados do POST.
-     *
-     * @param string $name Nome do campo a ser removido.
-     *
-     * @return self
-     */
-    public function del($name)
-    {
-        $fdata = $this->xcrud->_parse_field_names($name, 'cCrudPostdata');
-        foreach ($fdata as $key => $_) {
-            unset($this->postdata[$key]);
-        }
-        return $this;
-    }
-
-    /**
-     * Retorna o valor de um campo enviado.
-     *
-     * @param string $name Nome do campo.
-     *
-     * @return mixed|null Valor do campo ou null se não existir.
-     */
-    public function get(string $name): mixed
-    {
-        $fdata = $this->xcrud->_parse_field_names($name, 'PostData');
-        $fname = key($fdata) /*$fdata[0]['table'] . '.' . $fdata[0]['field']*/;
-        return $this->postdata[$fname] ?? null;
-    }
-
-    /**
-     * Converte os dados armazenados em array.
-     *
-     * @return array Dados do POST processados.
-     */
-    public function to_array()
-    {
-        return $this->postdata; // Entrega os dados para manipulação externa
-    }
-}
-
-/**
- * Alias para compatibilidade retroativa.
- */
-class_alias(PostData::class, __NAMESPACE__ . '\\cCrudPostdata');


### PR DESCRIPTION
## Summary
- extract Postdata handler into its own class file and alias legacy name
- update cCrud to import and instantiate the new Postdata class

## Testing
- `composer dump-autoload`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2d2a1ecc832a8cd7fc88a9ece8db