### PR TITLE
Add Ajax endpoint and CI4 routing

### DIFF
--- a/src/cCrud.php
+++ b/src/cCrud.php
@@ -30,11 +30,11 @@ class cCrud
     protected static $classes = array();
 
     /**
-     * Indica se a rota Ajax já foi registrada.
+     * Indica se as rotas do cCrud já foram registradas.
      *
      * @var bool
      */
-    protected static bool $ajaxRouteRegistered = false;
+    protected static bool $routesRegistered = false;
 
     protected $ajax_request = false;
 
@@ -580,24 +580,26 @@ class cCrud
         );
         $this->nested_readonly_on_view = $this->config->nested_readonly_on_view;
 
-        // garante o registro da rota Ajax do cCrud
-        self::registerAjaxRoute();
+        // garante o registro das rotas do cCrud
+        self::registerRoutes();
     }
 
     protected function __clone()
     {}
 
     /**
-     * Registra a rota de processamento Ajax do cCrud.
+     * Registra as rotas utilizadas pelo cCrud.
      *
      * @return void
      */
-    private static function registerAjaxRoute(): void
+    private static function registerRoutes(): void
     {
-        if (self::$ajaxRouteRegistered === false) {
-            // registra a rota apenas uma vez
-            Services::routes()->post('ccrud/ajax', 'cCrud::ajax', ['namespace' => 'cCrud']);
-            self::$ajaxRouteRegistered = true;
+        if (self::$routesRegistered === false) {
+            // registra as rotas apenas uma vez
+            Services::routes()->post('ajax', 'cCrud::ajax', ['namespace' => 'cCrud']);
+            Services::routes()->get('cCrud.css', 'cCrud::css', ['namespace' => 'cCrud']);
+            Services::routes()->get('cCrud.js', 'cCrud::js', ['namespace' => 'cCrud']);
+            self::$routesRegistered = true;
         }
     }
 
@@ -752,6 +754,28 @@ class cCrud
 
         // retorna o conteúdo como uma resposta HTTP
         return Services::response()->setBody($output);
+    }
+
+    /**
+     * Retorna o conteúdo CSS utilizado pelo cCrud.
+     *
+     * @return ResponseInterface Resposta HTTP contendo o CSS
+     */
+    public function css(): ResponseInterface
+    {
+        $content = file_get_contents(CCRUD_PATH . '/views/cCrud.css');
+        return Services::response()->setContentType('text/css')->setBody($content);
+    }
+
+    /**
+     * Retorna o conteúdo JavaScript utilizado pelo cCrud.
+     *
+     * @return ResponseInterface Resposta HTTP contendo o JavaScript
+     */
+    public function js(): ResponseInterface
+    {
+        $content = file_get_contents(CCRUD_PATH . '/views/cCrud.js');
+        return Services::response()->setContentType('application/javascript')->setBody($content);
     }
 
     public function connection($user = '', $pass = '', $table = '', $host = 'localhost', $encode = 'utf8')
@@ -9907,6 +9931,7 @@ class cCrud
             $out .= '<link href="' . $config->scripts_url . '/' . $config->plugins_uri . '/jquery-ui/jquery-ui.min.css?' . time() . '" rel="stylesheet" type="text/css" />';
         if ($config->load_jcrop)
             $out .= '<link href="' . $config->scripts_url . '/' . $config->plugins_uri . '/jcrop/jquery.Jcrop.min.css?' . time() . '" rel="stylesheet" type="text/css" />';
+        $out .= '<link href="/cCrud.css" rel="stylesheet" type="text/css" />';
 
         return $out;
     }
@@ -9986,6 +10011,7 @@ class cCrud
 
             -->
             </script>';
+        $out .= '<script src="/cCrud.js"></script>';
         return $out;
     }
 

--- a/src/cCrud.php
+++ b/src/cCrud.php
@@ -8,6 +8,7 @@ use CodeIgniter\I18n\Time;
 use Config\Services;
 use CodeIgniter\Encryption\EncrypterInterface;
 use CodeIgniter\Session\Session;
+use CodeIgniter\HTTP\ResponseInterface;
 use cCrud\Postdata;
 use RuntimeException;
 
@@ -27,6 +28,13 @@ class cCrud
     protected static $js_loaded = false;
 
     protected static $classes = array();
+
+    /**
+     * Indica se a rota Ajax já foi registrada.
+     *
+     * @var bool
+     */
+    protected static bool $ajaxRouteRegistered = false;
 
     protected $ajax_request = false;
 
@@ -571,10 +579,27 @@ class cCrud
             'php_t' => $this->config->php_time_format
         );
         $this->nested_readonly_on_view = $this->config->nested_readonly_on_view;
+
+        // garante o registro da rota Ajax do cCrud
+        self::registerAjaxRoute();
     }
 
     protected function __clone()
     {}
+
+    /**
+     * Registra a rota de processamento Ajax do cCrud.
+     *
+     * @return void
+     */
+    private static function registerAjaxRoute(): void
+    {
+        if (self::$ajaxRouteRegistered === false) {
+            // registra a rota apenas uma vez
+            Services::routes()->post('ccrud/ajax', 'cCrud::ajax', ['namespace' => 'cCrud']);
+            self::$ajaxRouteRegistered = true;
+        }
+    }
 
     public function __toString()
     {
@@ -713,6 +738,20 @@ class cCrud
                 throw new RuntimeException(lang('cCrud.session_creation_failed'));
             }
         }
+    }
+
+    /**
+     * Processa requisições Ajax encaminhadas ao cCrud.
+     *
+     * @return ResponseInterface Resposta HTTP contendo o resultado da operação
+     */
+    public function ajax(): ResponseInterface
+    {
+        // obtém a resposta processada pela instância solicitada
+        $output = self::get_requested_instance($this->model);
+
+        // retorna o conteúdo como uma resposta HTTP
+        return Services::response()->setBody($output);
     }
 
     public function connection($user = '', $pass = '', $table = '', $host = 'localhost', $encode = 'utf8')

--- a/src/config/cCrud.php
+++ b/src/config/cCrud.php
@@ -139,7 +139,7 @@ class cCrud extends BaseConfig
     // urls (relative to $scripts_url or xcrud's folder, if $scripts_url is not defined)
     public $plugins_uri = 'plugins'; // scripts and libraries
     public $lang_uri = 'application/language'; // js files
-    public $ajax_uri = 'ajax/xcrud'; // main ajax file or url
+    public $ajax_uri = 'ajax'; // main ajax file ou url
     // paths (relative to xcrud's folder)
     public $lang_path = '../../language/'; // ini files
     // external session


### PR DESCRIPTION
## Summary
- add ajax() method to cCrud returning response
- register Ajax route dynamically when cCrud is instantiated

## Testing
- `php -l src/cCrud.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_68ab30b40d00832a853e8761b95eb5c9