### PR TITLE
Evitar acesso a Model não inicializado

### DIFF
--- a/src/cCrud.php
+++ b/src/cCrud.php
@@ -54,9 +54,9 @@ class cCrud
     /**
      * Model utilizado para todas as consultas ao banco de dados.
      *
-     * @var Model
+     * @var Model|null
      */
-    protected Model $model;
+    protected ?Model $model = null;
 
     /**
      * Manipulador de sessões do CodeIgniter 4.


### PR DESCRIPTION
## Sumário
- corrigir propriedade `Model` não inicializada

## Testes
- `php -l src/cCrud.php`
- `composer validate --no-check-publish` *(falhou: version does not match expected pattern)*
- `composer test` *(falhou: Command "test" is not defined.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc7e5e8b14832ab15bb99597ae0f6b