### PR TITLE
Implementa rotas c/* para o cCrud

### DIFF
--- a/src/cCrud.php
+++ b/src/cCrud.php
@@ -10,6 +10,7 @@ use CodeIgniter\Session\Session;
 use CodeIgniter\HTTP\ResponseInterface;
 use cCrud\Postdata;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 // direct access to DB driver and config
 define('CCRUD_PATH', str_replace('\\', '/', dirname(__file__)));
@@ -35,12 +36,6 @@ class cCrud
 
     protected static $classes = array();
 
-    /**
-     * Indica se as rotas do cCrud já foram registradas.
-     *
-     * @var bool
-     */
-    protected static bool $routesRegistered = false;
 
     protected $ajax_request = false;
 
@@ -54,9 +49,9 @@ class cCrud
     /**
      * Model utilizado para todas as consultas ao banco de dados.
      *
-     * @var Model
+     * @var Model|null
      */
-    protected Model $model;
+    protected ?Model $model = null;
 
     /**
      * Manipulador de sessões do CodeIgniter 4.
@@ -524,56 +519,65 @@ class cCrud
      * @param Model $model            Modelo do CodeIgniter utilizado pelo CRUD
      * @param LoggerInterface|null $logger Registrador de logs opcional
      */
-    public function __construct(Model $model, ?LoggerInterface $logger = null)
+    /**
+     * Construtor da classe principal do cCrud.
+     *
+     * @param Model|null          $model  Modelo do CodeIgniter utilizado pelo CRUD
+     * @param LoggerInterface|null $logger Manipulador de logs do framework
+     */
+    public function __construct(?Model $model = null, ?LoggerInterface $logger = null)
     {
-        // Define o Model e o Logger utilizados pelo cCrud
+        // Define o Model e o Logger utilizados pelo cCrud, quando fornecidos
         $this->model  = $model;
         $this->logger = $logger ?? Services::logger();
 
-        // Define automaticamente a tabela e o nome exibido a partir do Model
-        $this->table      = property_exists($model, 'table') ? $model->table : '';
-        $this->table_name = $model->tableName;
+        if ($model !== null) {
+            // Define automaticamente a tabela e o nome exibido a partir do Model
+            $this->table      = property_exists($model, 'table') ? $model->table : '';
+            $this->table_name = $model->tableName;
 
-        // Carrega rótulos definidos na Entity associada, caso existam
-        $returnType = method_exists($model, 'getReturnType') ? $model->getReturnType() : $model->returnType;
-        if ($returnType && class_exists($returnType)) {
-            $entity = new $returnType();
-            if (property_exists($entity, 'labels') && is_array($entity->labels)) {
-                foreach ($entity->labels as $field => $label) {
-                    $this->labels[$field] = $label;
-                    if ($this->table) {
-                        $this->labels[$this->table . '.' . $field] = $label;
+            // Carrega rótulos definidos na Entity associada, caso existam
+            $returnType = method_exists($model, 'getReturnType') ? $model->getReturnType() : $model->returnType;
+            if ($returnType && class_exists($returnType)) {
+                $entity = new $returnType();
+                if (property_exists($entity, 'labels') && is_array($entity->labels)) {
+                    foreach ($entity->labels as $field => $label) {
+                        $this->labels[$field] = $label;
+                        if ($this->table) {
+                            $this->labels[$this->table . '.' . $field] = $label;
+                        }
                     }
                 }
             }
         }
-        $this->table_name = $model->tableName;
-
-        // Carrega rótulos definidos na Entity associada, caso existam
-        $returnType = method_exists($model, 'getReturnType') ? $model->getReturnType() : $model->returnType;
-        if ($returnType && class_exists($returnType)) {
-            $entity = new $returnType();
-            if (property_exists($entity, 'labels') && is_array($entity->labels)) {
-                foreach ($entity->labels as $field => $label) {
-                    $this->labels[$field] = $label;
-                    if ($this->table) {
-                        $this->labels[$this->table . '.' . $field] = $label;
-                    }
-                }
-            }
-        }
-
-        // Define o Model e o Logger utilizados pelo cCrud
-        $this->model  = $model;
-        $this->logger = $logger ?? Services::logger();
 
         // Inicia o manipulador de sessões do CodeIgniter 4
         $this->session = Services::session();
 
         $this->config = cCrudConfig::instance();
 
-        $this->limit = $this->config->limit;
-        $this->limit_list = $this->config->limit_list;
+        // Verifica se as rotas base estão configuradas no CodeIgniter
+        $requestUri = trim($this->config->request_uri, '/');
+        $routes     = Services::routes();
+        $configured = false;
+        foreach ($routes->getRoutes() as $methods) {
+            foreach (array_keys($methods) as $route) {
+                if (strpos($route, $requestUri) === 0) {
+                    $configured = true;
+                    break 2;
+                }
+            }
+        }
+        if (! $configured) {
+            $message = "Rota base \"{$requestUri}\" não configurada. Adicione ao arquivo app/Config/Routes.php:\n" .
+                "\$routes->group('{$requestUri}', ['namespace' => 'cCrud'], static function (RouteCollection \$routes): void {\n" .
+                "    \$routes->add('(:any)', 'cCrud::router');\n" .
+                "});";
+            throw new RuntimeException($message);
+        }
+
+        $this->limit              = $this->config->limit;
+        $this->limit_list         = $this->config->limit_list;
         $this->column_cut = $this->config->column_cut;
         $this->show_primary_ai_field = $this->config->show_primary_ai_field;
         $this->show_primary_ai_column = $this->config->show_primary_ai_column;
@@ -609,30 +613,10 @@ class cCrud
         );
         $this->nested_readonly_on_view = $this->config->nested_readonly_on_view;
 
-        // garante o registro das rotas do cCrud
-        self::registerRoutes();
     }
 
     protected function __clone()
     {}
-
-    /**
-     * Registra as rotas utilizadas pelo cCrud.
-     *
-     * @return void
-     */
-    private static function registerRoutes(): void
-    {
-        if (self::$routesRegistered === false) {
-            // registra as rotas apenas uma vez
-            $config    = cCrudConfig::instance();
-            $ajaxRoute = trim($config->ajax_uri, '/');
-            Services::routes()->post($ajaxRoute, 'cCrud::ajax', ['namespace' => 'cCrud']);
-            Services::routes()->get('cCrud.css', 'cCrud::css', ['namespace' => 'cCrud']);
-            Services::routes()->get('cCrud.js', 'cCrud::js', ['namespace' => 'cCrud']);
-            self::$routesRegistered = true;
-        }
-    }
 
     /**
      * Retorna a saída renderizada do componente.
@@ -705,12 +689,12 @@ class cCrud
     /**
      * Recupera a instância solicitada via requisição Ajax.
      *
-     * @param Model               $model  Modelo associado
+     * @param Model|null          $model  Modelo associado, quando disponível
      * @param LoggerInterface|null $logger Registrador de logs opcional
      *
      * @return string|ResponseInterface
      */
-    public static function getRequestedInstance(Model $model, ?LoggerInterface $logger = null)
+    public static function getRequestedInstance(?Model $model = null, ?LoggerInterface $logger = null)
     {
         $request  = Services::request();
         $security = Services::security();
@@ -772,6 +756,23 @@ class cCrud
         if (is_callable($config->before_construct)) {
             call_user_func($config->before_construct);
         }
+    }
+
+    /**
+     * Encaminha as requisições recebidas para o manipulador adequado.
+     *
+     * @return ResponseInterface Resposta HTTP do recurso solicitado
+     */
+    public function router(): ResponseInterface
+    {
+        $segment = Services::uri()->getSegment(2);
+
+        return match ($segment) {
+            'ajax' => $this->ajax(),
+            'css'  => $this->css(),
+            'js'   => $this->js(),
+            default => Services::response()->setStatusCode(ResponseInterface::HTTP_NOT_FOUND),
+        };
     }
 
     /**
@@ -9255,8 +9256,8 @@ class cCrud
         if ($crop) {
             $params['cCrud']['crop'] = $crop;
         }
-        $ajaxUri = '/' . trim($this->config->ajax_uri, '/');
-        return $ajaxUri . '?' . http_build_query($params);
+        $requestUri = '/' . trim($this->config->request_uri, '/') . '/ajax';
+        return $requestUri . '?' . http_build_query($params);
     }
 
     protected function real_file_link($filename, $params, $is_details = false)
@@ -9677,7 +9678,7 @@ class cCrud
             $out .= '<link href="' . $lib . '" rel="stylesheet" type="text/css" />';
         }
 
-        $out .= '<link href="/cCrud.css" rel="stylesheet" type="text/css" />';
+        $out .= '<link href="/' . trim($config->request_uri, '/') . '/css" rel="stylesheet" type="text/css" />';
 
         return $out;
     }
@@ -9709,10 +9710,10 @@ class cCrud
             $out .= '<script src="' . $lib . '"></script>';
         }
 
-        $out .= '<script src="/cCrud.js"></script>';
+        $out .= '<script src="/' . trim($config->request_uri, '/') . '/js"></script>';
 
         $settings = [
-            'url' => '/' . trim($config->ajax_uri, '/'),
+            'url' => '/' . trim($config->request_uri, '/') . '/ajax',
             'table_name' => $instance ? $instance->table_name : '',
             'force_editor' => $config->force_editor,
             'date_first_day' => $config->date_first_day,

--- a/src/config/cCrud.php
+++ b/src/config/cCrud.php
@@ -39,11 +39,11 @@ class cCrud extends BaseConfig
     ];
 
     /**
-     * Endpoint utilizado para as requisições AJAX do cCrud.
+     * URI base utilizada pelo cCrud para processar requisições.
      *
      * @var string
      */
-    public string $ajax_uri = 'ajax';
+    public string $request_uri = 'c';
 
     
     // editor

--- a/teste/app/Config/Routes.php
+++ b/teste/app/Config/Routes.php
@@ -15,5 +15,12 @@ $routes = Services::routes();
 // Rota padrão para a página inicial
 $routes->get('/', 'Home::index');
 
+/**
+ * Rotas de integração com o cCrud.
+ */
+$routes->group('c', ['namespace' => 'cCrud'], static function (RouteCollection $routes): void {
+    $routes->add('(:any)', 'cCrud::router');
+});
+
 return $routes;
 


### PR DESCRIPTION
## Summary
- permite instanciar cCrud sem Model para atender css, js e ajax
- define `request_uri` padrão como `c` e ajusta rotas de teste para esse prefixo

## Testing
- `composer install --no-interaction --no-progress`
- `cd teste && composer install --no-interaction --no-progress`
- `cd teste && vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_68bc9b821c8c832aa77bac32d3ec47c3