### PR TITLE
Ajusta overlay em tela cheia com spinner centralizado

### DIFF
--- a/src/views/cCrud.css
+++ b/src/views/cCrud.css
@@ -50,17 +50,17 @@ td.cCrud-actions{
     border-left: none;
     margin-top: -1px;
 }
-
+/* Overlay de carregamento em tela cheia */
 .cCrud-overlay{
-    /*display: none;*/
-    position: absolute;
+    display: none;
+    position: fixed;
     top: 0;
     left: 0;
-    bottom: 0;
+    width: 100vw;
+    height: 100vh;
     background: #ffffff;
     opacity: 0.5;
-    width: 100%;
-    z-index: 9;
+    z-index: 1050;
 }
 .cCrud-num{
     color: #bbb;

--- a/src/views/container.php
+++ b/src/views/container.php
@@ -10,9 +10,11 @@
 	<div class="cCrud-ajax">
     	<?=$content ?>
     </div>
-	<div class="cCrud-overlay">
-		<div class="spinner-border" style="width: 3rem; height: 3rem;" role="status">
-			<span class="visually-hidden">Loading...</span>
-		</div>
-	</div>
+        <div class="cCrud-overlay">
+                <div class="w-100 h-100 d-flex justify-content-center align-items-center">
+                        <div class="spinner-border" style="width: 3rem; height: 3rem;" role="status">
+                                <span class="visually-hidden">Loading...</span>
+                        </div>
+                </div>
+        </div>
 </div>


### PR DESCRIPTION
## Resumo
- Ajusta overlay para ocupar toda a janela
- Centraliza spinner com utilitários do Bootstrap

## Testes
- `php -l src/views/container.php`
- `composer validate --no-check-lock`


------
https://chatgpt.com/codex/tasks/task_e_68bdde29448c832ab8f2a6c485455528